### PR TITLE
attempt to build with macOS 10.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
       - BUILD_DEPENDS=""
       - TEST_DEPENDS="pytest pytest-cov numpy scipy"
       - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
+      - MACOSX_DEPLOYMENT_TARGET=10.11
       # Following generated with
       # travis encrypt -r python-pillow/pillow-wheels WHEELHOUSE_UPLOADER_SECRET=<the api key>
       - secure: "ky76goiK6n4k8V9/uG340GSFVwmjE7G76l9xbhhGZkcph4eTwN5VRM/tqyJvlNs/HZOhKSILfyGBeaG8qf7gHmwr0touPT+EjWn4TNV8iyVj75ZshgRE9DuaIAfdH89gW2m+BmvBDyzi0JE3KVCu55NcGm8h7Ecl6nmQ/c2iROY="


### PR DESCRIPTION
Since xcode9 changed the default, we just have to tell it to target 10.11.  This should do the trick.  It might be easy to support even older versions as well.

I’m not set up right now to test this change, so hoping the reviewer can run this build and test.

If you want to reject this on principle for asking the reviewer to do the testing I fully respect that! :-)